### PR TITLE
Remove RLMObject and RealmSwift.

### DIFF
--- a/Bookshelf/Book.swift
+++ b/Bookshelf/Book.swift
@@ -137,12 +137,4 @@ class Book: Entity, Codable {
         super.init()
     }
     
-    required init(realm: RLMRealm, schema: RLMObjectSchema) {
-        super.init(realm: realm, schema: schema)
-    }
-    
-    required init(value: Any, schema: RLMSchema) {
-        super.init(value: value, schema: schema)
-    }
-    
 }


### PR DESCRIPTION
The designated initializers defined by RLMObject and RealmSwift.Object when inheriting Entity, File, etc. are no longer required.